### PR TITLE
Testing MP Metrics against Bootable JAR - Excluding tests requiring a 'module.path' system property from metrics module

### DIFF
--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -143,6 +143,10 @@
                                     <excludes>
                                         <!-- Need MP FaultTolerance -->
                                         <exclude>org/jboss/eap/qe/microprofile/metrics/integration/ft/*Test.java</exclude>
+                                        <!-- The following test cases need for a module.path system property to be set
+                                         which doesn't make sense with Bootable JAR -->
+                                        <exclude>org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceProviderTest</exclude>
+                                        <exclude>org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceTest</exclude>
                                     </excludes>
                                 </configuration>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <version.org.eclipse.microprofile>3.3</version.org.eclipse.microprofile>
         <version.org.jboss.arquillian>1.5.0.Final</version.org.jboss.arquillian>
         <version.org.jboss.wildfly.dist>20.0.0.Final</version.org.jboss.wildfly.dist>
-        <version.org.wildfly.arquillian>3.0.0.Beta2</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>3.0.0.Beta3</version.org.wildfly.arquillian>
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
         <!-- wildfly-core update needed to have the launcher version with BootableJarCommandBuilder used to start
         the server up -->
@@ -62,9 +62,9 @@
         <galleon.log.time>true</galleon.log.time>
         <testsuite.galleon.pack.groupId>org.wildfly</testsuite.galleon.pack.groupId>
         <testsuite.galleon.pack.artifactId>wildfly-galleon-pack</testsuite.galleon.pack.artifactId>
-        <testsuite.galleon.pack.version>20.0.0.Final</testsuite.galleon.pack.version>
+        <testsuite.galleon.pack.version>20.0.1.Final</testsuite.galleon.pack.version>
         <!-- Bootable JAR -->
-        <version.org.wildfly.jar.plugin>2.0.0.Beta2</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>2.0.0.Beta3</version.org.wildfly.jar.plugin>
     </properties>
 
     <dependencyManagement>
@@ -505,11 +505,6 @@
         <!-- Test against Bootable JAR -->
         <profile>
             <id>bootablejar.profile</id>
-            <properties>
-                <!-- TBD - remove once https://issues.redhat.com/browse/WFARQ-74 is done and wildfly-arquillian-3.0.0.Beta2 is out -->
-                <jboss.home>${project.build.directory}</jboss.home>
-                <jboss.modules.path>${basedir}/target/jboss-as-bootable/modules</jboss.modules.path>
-            </properties>
             <activation>
                 <property>
                     <name>ts.bootable</name>


### PR DESCRIPTION
Some Metrics tests needing a 'module.path' property have been excluded since such property has no meaning in the Bootable JAR context.

```
$ mvn clean verify -Dmaven.repo.local=/home/fburzigo/projects/git/jboss-eap-qe/eap-microprofile-test-suite/local-repo -pl microprofile-config,microprofile-health,microprofile-metrics,microprofile-opentracing -am -Dts.bootable
...
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- maven-jar-plugin:3.1.0:jar (default-jar) @ microprofile-opentracing ---
[INFO] Building jar: /home/fburzigo/projects/git/jboss-eap-qe/eap-microprofile-test-suite/microprofile-opentracing/target/microprofile-opentracing-1.0.0.Final-SNAPSHOT.jar
[INFO] 
[INFO] --- maven-source-plugin:3.0.1:jar-no-fork (attach-sources) @ microprofile-opentracing ---
[INFO] Building jar: /home/fburzigo/projects/git/jboss-eap-qe/eap-microprofile-test-suite/microprofile-opentracing/target/microprofile-opentracing-1.0.0.Final-SNAPSHOT-sources.jar
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Test suite for MicroProfile on WF/EAP 1.0.0.Final-SNAPSHOT:
[INFO] 
[INFO] Test suite for MicroProfile on WF/EAP .............. SUCCESS [  0.925 s]
[INFO] tooling-server-configuration ....................... SUCCESS [  3.609 s]
[INFO] tooling-docker ..................................... SUCCESS [ 20.783 s]
[INFO] microprofile-config ................................ SUCCESS [ 25.929 s]
[INFO] microprofile-health ................................ SUCCESS [ 29.957 s]
[INFO] microprofile-metrics ............................... SUCCESS [ 39.860 s]
[INFO] microprofile-opentracing ........................... SUCCESS [ 31.364 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:32 min
[INFO] Finished at: 2020-09-03T17:28:48+02:00
[INFO] ------------------------------------------------------------------------
```